### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ dash:
 ```
 ## Using this theme directly on Github Pages
 
-Please keep in mind that Github Pages does only support [a limited list of Jekyll plugins](https://pages.github.com/versions). You will be able to use this theme on Github Pages but some functionality might not be available, for example displaying tags. In order to use this theme to a full extend, you have to generate the `_site` externally, for example on [TravisCI](https://travis-ci.org). 
+Please keep in mind that Github Pages does only support [a limited list of Jekyll plugins](https://help.github.com/en/articles/configuring-jekyll-plugins#default-plugins). You will be able to use this theme on Github Pages but some functionality might not be available, for example displaying tags. In order to use this theme to a full extend, you have to generate the `_site` externally, for example on [TravisCI](https://travis-ci.org). 
 
 For example, you want to host your own blog on `https://<username>.github.io`. As a result, you require the following repositories:
 


### PR DESCRIPTION
I corrected referenced GitHub Page URL on README, as the original link referenced the dependencies of the `github-pages` gem itself and not the allowed whitelisted set of Jekyll plugins on GitHub Pages.

Reference: https://jekyllrb.com/docs/github-pages/