### PR TITLE
Add support for GitHub avatars to replace Gravatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ dash:
       color: purple
       
   show_author: true
+
+# Replaces the default avatar provider (gravatar)
+#avatar_source: github
+#github_username: bitbrain
 ```
 ## Using this theme directly on Github Pages
 

--- a/_config.yml
+++ b/_config.yml
@@ -47,5 +47,6 @@ plugins:
  - liquid-md5
  - jekyll/tagging
 
+# Replaces the default avatar provider (gravatar)
 #avatar_source: github
 #github_username: bitbrain

--- a/_config.yml
+++ b/_config.yml
@@ -44,3 +44,6 @@ plugins:
  - jekyll-paginate
  - liquid-md5
  - jekyll/tagging
+
+avatar_source: github
+github_username: bitbrain

--- a/_config.yml
+++ b/_config.yml
@@ -47,5 +47,5 @@ plugins:
  - liquid-md5
  - jekyll/tagging
 
-avatar_source: github
-github_username: bitbrain
+#avatar_source: github
+#github_username: bitbrain

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,6 +1,15 @@
 <div class="author-box">
-{% if site.plugins contains "liquid-md5" %}
-<img src="https://gravatar.com/avatar/{{ site.email | downcase | md5 }}?s=256" class="author-avatar" />
-{% endif %}
+    {% if site.avatar_source == "gravatar" and site.plugins contains "liquid-md5" %}
+        {% capture avatar_image %}
+            https://gravatar.com/avatar/{{ site.email | downcase | md5 }}?s=256
+        {% endcapture %}
+    {% elsif site.avatar_source == "github" and site.github_username %}
+        {% capture avatar_image %}
+            https://github.com/{{ site.github_username }}.png
+        {% endcapture %}
+    {% endif %}
+    {% if avatar_image %}
+        <img src="{{ avatar_image }}" class="author-avatar" />
+    {% endif %}
 {{ site.description }}
 </div>

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -9,7 +9,7 @@
         {% endcapture %}
     {% endif %}
     {% if avatar_image %}
-        <img src="{{ avatar_image }}" class="author-avatar" />
+        <img src="{{ avatar_image }}" class="author-avatar" alt="Avatar" />
     {% endif %}
 {{ site.description }}
 </div>

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,11 +1,11 @@
 <div class="author-box">
-    {% if site.avatar_source == "gravatar" and site.plugins contains "liquid-md5" %}
-        {% capture avatar_image %}
-            https://gravatar.com/avatar/{{ site.email | downcase | md5 }}?s=256
-        {% endcapture %}
-    {% elsif site.avatar_source == "github" and site.github_username %}
+    {% if site.avatar_source == "github" and site.github_username %}
         {% capture avatar_image %}
             https://github.com/{{ site.github_username }}.png
+        {% endcapture %}
+    {% elsif site.plugins contains "liquid-md5" %}
+        {% capture avatar_image %}
+            https://gravatar.com/avatar/{{ site.email | downcase | md5 }}?s=256
         {% endcapture %}
     {% endif %}
     {% if avatar_image %}


### PR DESCRIPTION
# Description

I don't have a Gravatar account (asks for a WordPress.com account...) so I added a way to use GitHub avatar on the main page instead of Gravatar.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

I manually tested the different possible combinations in `_config.yml`.

- [x] `avatar_source: SOMETHING`
- [x] `avatar_source: gravatar`
- [x] `avatar_source: github` and no `github_username`
- [x] `avatar_source: github` and `github_username: NON_EXISTING`
- [x] `avatar_source: github` and `github_username: bitbrain`

# Checklist:

- [ ] Check if github_username really exists
- [x] Make `avatar_source: gravatar` the default (change becomes non-breaking)
- [x] Add documentation in `README.md`