### PR TITLE
Fix collapsing margins in post tags

### DIFF
--- a/_sass/dash/_layout.scss
+++ b/_sass/dash/_layout.scss
@@ -270,6 +270,11 @@
   }
 }
 
+.tag {
+  display: inline-block;
+  margin: 0.3em 0.3em 0.3em 0;
+}
+
 .post-tags {
   margin-top: 0.3em;
   margin-bottom: 0.5em;

--- a/_sass/dash/_layout.scss
+++ b/_sass/dash/_layout.scss
@@ -278,6 +278,7 @@
 .post-tags {
   margin-top: 0.3em;
   margin-bottom: 0.5em;
+  text-align: initial;
 }
 
 .credits {


### PR DESCRIPTION
# Description

This pull request fixes the following collapsing margins in post tags.

_Before_ on desktops:
![before-desktop](https://user-images.githubusercontent.com/30960791/72209765-4e421c80-34b2-11ea-9b43-2c6334bebaa6.png)

_After_ on desktops:
![after-desktop](https://user-images.githubusercontent.com/30960791/72209763-4da98600-34b2-11ea-8668-5e875c6b97b1.png)

_Before_ on mobile:
![before-mobile](https://user-images.githubusercontent.com/30960791/72209766-4e421c80-34b2-11ea-9905-f5a9d0185d05.png)

_After_ on mobile:
![after-mobile](https://user-images.githubusercontent.com/30960791/72209764-4e421c80-34b2-11ea-8d03-ea53f08124bd.png)

## Type of change

- Style fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Using the latest version of Firefox to test both desktop and mobile views. 