### PR TITLE
Fix margins between tags in "all tags"

### DIFF
--- a/_sass/dash/_layout.scss
+++ b/_sass/dash/_layout.scss
@@ -241,7 +241,7 @@
    text-align: left;
    & > a {
      display: inline-block;
-     margin-bottom: 1em;
+     margin: 0.3em 0.3em 0.3em 0;
    }
  }
 


### PR DESCRIPTION
# Description

This pull request fixes margins between tags in "all tags" section.

Screenshot **before** the fix:
![before-alltags](https://user-images.githubusercontent.com/30960791/72211255-76d51100-34c8-11ea-88c6-ea42ce20c786.png)

Screenshot **after** the fix:
![after-alltags](https://user-images.githubusercontent.com/30960791/72211258-818fa600-34c8-11ea-867b-e1d1f41f35c6.png)

## Type of change

- Style fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Using the latest version of Firefox.