### PR TITLE
Set post link text-align property to initial

### DIFF
--- a/_sass/dash/_layout.scss
+++ b/_sass/dash/_layout.scss
@@ -226,6 +226,8 @@
    & > .post-link {
      font-size: $base-font-size;
      font-size: $post-link-font-size;
+     display: inline-block;
+     text-align: initial;
    }
 
    & > .post-meta {


### PR DESCRIPTION
# Description

The post title text in the home page is currently justified. This pull request changes the text-align property to initial (default value).

Screenshot **before** the fix:
![before-recent](https://user-images.githubusercontent.com/30960791/72211517-0250a100-34cd-11ea-9c9b-71291ea21593.png)

Screenshot **after** the fix:
![after-recent](https://user-images.githubusercontent.com/30960791/72211518-041a6480-34cd-11ea-9eda-dd83cb7adfec.png)

## Type of change

- Style fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Using the latest version of Firefox.