### PR TITLE
Add a show_author variable in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,8 @@ dash:
       icon: github-square
       color: purple
 
+  show_author: true
+
 # Build settings
 theme: jekyll-dash
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,7 +1,9 @@
 ---
 layout: default
 ---
-{% include author.html %}
+{% unless site.dash.show_author == false %}
+  {% include author.html %}
+{% endunless %}
 {% assign posts_count = paginator.posts | size %}
 {% if posts_count > 0 %}
 <h1>recent articles</h1>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,9 @@
 ---
 layout: default
 ---
-{% include author.html %}
+{% unless site.dash.show_author == false %}
+  {% include author.html %}
+{% endunless %}
 <div class="post">
   <h1 class="post-title">{{ page.title }}</h1>
   {% if site.plugins contains "jekyll/tagging" %}

--- a/_layouts/tag_page.html
+++ b/_layouts/tag_page.html
@@ -1,7 +1,9 @@
 ---
 layout: default
 ---
-{% include author.html %}
+{% unless site.dash.show_author == false %}
+  {% include author.html %}
+{% endunless %}
 <h1 class="post-title">articles tagged with <a class="tag" href="/tag/{{ page.tag }}/">{{ page.tag }}</a></h1>
   <div class="post-links">
   {% for post in site.posts %}


### PR DESCRIPTION
# Description

This branch adds a new variable called show_author to _config.yml. When show_author is set to false, no author will be shown on all pages.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

I tested the following options:

- show_author set to true: Author block is shown
- show_author set to false: Author block is not shown
- show_author not defined: Author block is shown

# Checklist:

- Add documentation about using this option in README.md