### PR TITLE
Wrap long post descriptions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,8 @@ dash:
 
   show_author: true
 
+  animation_speed: 50
+
 # Build settings
 theme: jekyll-dash
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -52,7 +52,7 @@ layout: default
 <script>
   let i = 0;
   const text = '{{ page.description }}';
-  const speed = 50;
+  const speed = parseInt('{{ animation_speed }}');
   
   function typeWriter() {
     if (i < text.length) {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,6 +18,7 @@ layout: default
   <noscript>
     <div class="post-description">{{ page.description }}</div>
   </noscript>
+  <div id="animated-post-description" class="post-description" style="display: none;"></div>
   {% endif %}
   {{ content }}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -47,3 +47,20 @@ layout: default
 </div>
 {% endif %}
 {% include tagcloud.html %}
+
+<script>
+  let i = 0;
+  const text = '{{ page.description }}';
+  const speed = 50;
+  
+  function typeWriter() {
+    if (i < text.length) {
+      document.getElementById('animated-post-description').innerHTML += text.charAt(i);
+      i++;
+      setTimeout(typeWriter, speed);
+    }
+  }
+
+  document.getElementById('animated-post-description').style.display = 'initial';
+  typeWriter();
+</script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,9 @@ layout: default
   {% endif %}
   <div class="post-date">Published on {{ page.date | date_to_string }}</div>
   {% if page.description != null %}
-  <div class="post-description">{{ page.description }}</div>
+  <noscript>
+    <div class="post-description">{{ page.description }}</div>
+  </noscript>
   {% endif %}
   {{ content }}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -48,6 +48,7 @@ layout: default
 {% endif %}
 {% include tagcloud.html %}
 
+{% assign animation_speed = site.dash.animation_speed | default: 50 %}
 <script>
   let i = 0;
   const text = '{{ page.description }}';

--- a/_sass/dash/_layout.scss
+++ b/_sass/dash/_layout.scss
@@ -88,7 +88,6 @@
   @include themed() {
      color: t('foreground-color');
   }
-  white-space: nowrap;
   overflow: hidden;
   width: 100%;
   margin-bottom: 1em;

--- a/_sass/dash/_layout.scss
+++ b/_sass/dash/_layout.scss
@@ -91,7 +91,6 @@
   white-space: nowrap;
   overflow: hidden;
   width: 100%;
-  animation: type 2s steps(60, end);
   margin-bottom: 1em;
   margin-left: 0.5em;
 


### PR DESCRIPTION
Hi,

I made this patch 3 months ago to wrap long post descriptions. But it's just a quick fix, I disabled the animation because it wasn't working as expected.

I'm submitting this pull request now as a workaround for issue #43.

Example:
![wrapped-post-description](https://user-images.githubusercontent.com/30960791/90068664-52a51100-dcf1-11ea-9e27-af48a87796eb.png)

Best regards,