### PR TITLE
Added support for standard FA badges

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,13 @@
   <div class="wrapper">
     <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}<b class="command_prompt"></b><b class="blinking_cursor">_</b></a>
     <span class="social_links">
-        {% for link in site.dash.social_links %}<a class="color-{{ link.color }}-hover" href="{{ link.url }}"><i class="fab fa-{{ link.icon }}"></i></a>{% endfor %}
+        {% for link in site.dash.social_links %}
+        {% if link.fa == true %}
+        <a class="color-{{ link.color }}-hover" href="{{ link.url }}"><i class="fa fa-{{ link.icon }}"></i></a>
+        {% else %}
+        <a class="color-{{ link.color }}-hover" href="{{ link.url }}"><i class="fab fa-{{ link.icon }}"></i></a>
+        {% endif %}
+        {% endfor %}
     </span>
   </div>
 </div>


### PR DESCRIPTION
Ran into the problem of FontAwesome not having a HackTheBox badge. Thought myself, let's just use a cube, its almost the same. 
My CSS + HTML skills are not that high, but managed to figure out what do do from the docs. Probably not the most elegant way of doing it, but it works just fine, all you have to do is to notate when you want to use a standard FA icon, as follows:
![code](https://user-images.githubusercontent.com/43758244/107656866-de89fc80-6c84-11eb-88b9-ac6ba9117786.png)

The changes in view can be seen below:
 - The problem can be seen here
![old](https://user-images.githubusercontent.com/43758244/107656434-71766700-6c84-11eb-9970-58d90056a9cd.png)
 - After the changes:
![new](https://user-images.githubusercontent.com/43758244/107656424-6f140d00-6c84-11eb-84e0-a657a50eff33.png)
