### PR TITLE
Right-to-Left support (addresses #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ dash:
   date_format: "%b %-d, %Y"
 
   disqus:
-    shortname: <your-disqus-shortname>
+    shortname: <your-disqus-shortname>  
+
+  # Replaces the default avatar provider (gravatar)
+  #avatar_source: github
+  #github_username: bitbrain
+  #avatar_source: local
+  #avatar_path: /assets/avatar.png
 
   # generate social links in footer
   # supported colors: green, red, orange, blue, cyan, pink, teal, yellow, indigo, purple
@@ -79,10 +85,6 @@ dash:
       color: purple
       
   show_author: true
-
-# Replaces the default avatar provider (gravatar)
-#avatar_source: github
-#github_username: bitbrain
 ```
 ## Using this theme directly on Github Pages
 

--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,15 @@ dash:
 
   animation_speed: 50
 
+  # possible values are ltr (default) or rtl
+  page_direction: rtl
+
+  # Replaces the default avatar provider (gravatar)
+  #avatar_source: github
+  #github_username: bitbrain
+  #avatar_source: local
+  #avatar_path: /assets/avatar.png
+
 # Build settings
 theme: jekyll-dash
 
@@ -48,9 +57,3 @@ plugins:
  - jekyll-paginate
  - liquid-md5
  - jekyll/tagging
-
-# Replaces the default avatar provider (gravatar)
-#avatar_source: github
-#github_username: bitbrain
-#avatar_source: local
-#avatar_path: /assets/avatar.png

--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ dash:
   animation_speed: 50
 
   # possible values are ltr (default) or rtl
-  page_direction: rtl
+  page_direction: ltr
 
   # Replaces the default avatar provider (gravatar)
   #avatar_source: github

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,19 +1,9 @@
 <div class="author-box">
-    {% if site.dash.avatar_source == "github" and site.dash.github_username %}
-        {% capture avatar_image %}
-            https://github.com/{{ site.github_username }}.png
-        {% endcapture %}
-    {% elsif site.dash.avatar_source == "local" and site.dash.avatar_path %}
-        {% capture avatar_image %}
-            {{site.dash.avatar_path}}
-        {% endcapture %}
-    {% elsif site.plugins contains "liquid-md5" %}
-        {% capture avatar_image %}
-            https://gravatar.com/avatar/{{ site.email | downcase | md5 }}?s=256
-        {% endcapture %}
-    {% endif %}
-    {% if avatar_image %}
-        <img src="{{ avatar_image }}" class="author-avatar" alt="Avatar" />
-    {% endif %}
-{{ site.description }}
+{% if site.dash.page_direction == 'rtl' %}
+<div class="description">{{ site.description }}</div>
+{%- include avatar.html -%}
+{% else %}
+{%- include avatar.html -%}
+<div class="description">{{ site.description }}</div>
+{% endif %}
 </div>

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,11 +1,11 @@
 <div class="author-box">
-    {% if site.avatar_source == "github" and site.github_username %}
+    {% if site.dash.avatar_source == "github" and site.dash.github_username %}
         {% capture avatar_image %}
             https://github.com/{{ site.github_username }}.png
         {% endcapture %}
-    {% elsif site.avatar_source == "local" and site.avatar_path %}
+    {% elsif site.dash.avatar_source == "local" and site.dash.avatar_path %}
         {% capture avatar_image %}
-            {{site.avatar_path}}
+            {{site.dash.avatar_path}}
         {% endcapture %}
     {% elsif site.plugins contains "liquid-md5" %}
         {% capture avatar_image %}

--- a/_includes/avatar.html
+++ b/_includes/avatar.html
@@ -1,0 +1,16 @@
+{% if site.dash.avatar_source == "github" and site.dash.github_username %}
+{% capture avatar_image %}
+    https://github.com/{{ site.github_username }}.png
+{% endcapture %}
+{% elsif site.dash.avatar_source == "local" and site.dash.avatar_path %}
+{% capture avatar_image %}
+    {{site.dash.avatar_path}}
+{% endcapture %}
+{% elsif site.plugins contains "liquid-md5" %}
+{% capture avatar_image %}
+    https://gravatar.com/avatar/{{ site.email | downcase | md5 }}?s=256
+{% endcapture %}
+{% endif %}
+{% if avatar_image %}
+<img src="{{ avatar_image }}" class="author-avatar" alt="Avatar" />
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+<html class="{% if site.dash.page_direction == 'rtl'%}direction--rtl{% else %}direction--ltr{% endif %}"lang="{{ page.lang | default: site.lang | default: "en" }}">
 
   {%- include head.html -%}
 

--- a/_sass/dash/_layout.scss
+++ b/_sass/dash/_layout.scss
@@ -52,21 +52,75 @@
 }
 
 /**
- * Author box
+ * Right-to-Left support
  */
+
+ html.direction--rtl {
+  .author-box {
+    text-align: right;
+    & > .description {
+      direction: rtl;
+    }
+    & > img {
+      margin-right: 0em;
+      margin-left: 1em;
+    }
+  }
+  ol > li, ul > li {
+    text-align: right;
+    direction: rtl;
+    &::before {
+      float: right;
+      margin-left: 0.5em;
+    }
+  }
+  h1, h2, h3, h4, h5, h6 {
+    direction: rtl;
+    text-align: right;
+  }
+  .post-link-wrapper {
+    direction: rtl;
+  }
+  .post {
+    direction: rtl;
+  }
+  .pagination {
+    text-align: right;
+  }
+  .tag-cloud {
+    direction: rtl;
+    text-align: right;
+  }
+  .related-posts {
+    direction: rtl;
+    text-align: right;
+
+    & > li::before {
+      margin-right: 0;
+      margin-left: 0.5em;
+    }
+  }
+  pre {
+    direction: ltr;
+    text-align: left;
+  }
+}
 
  .author-box {
    margin-bottom: 1em;
    text-align: left;
    min-height: 72px;
    font-style: italic;
+   display: inline-flex;
+   & > .description {
+     flex:8;
+   }
    & > .author-avatar {
-     float: left;
-     white-space: pre-line;
      margin-right: 1em;
      width: 72px;
-     height: 72px;
+     height: 100%;
      border-radius: 0.3em;
+     flex: 1;
    }
  }
 


### PR DESCRIPTION
This pull request introduces Right-to-Left support for languages like Arabic. The support can be enabled by setting the following property in `_config.yml`:

```yml
dash:
  # possible values are ltr (default) or rtl
  page_direction: rtl
```

## Notable changes

- most elements should now render in RTL format when enabled
- the header image will now be aligned to the right when RTL is enabled to make it easier for the eye
- code remains unaffected by RTL (is this desired?)
- moved avatar source into `dash` namespace

## Screenshots (RTL)

![rtl-1](https://user-images.githubusercontent.com/822035/135963354-725e4182-1234-422e-8107-19ce35aa41e4.JPG)
![rtl-2](https://user-images.githubusercontent.com/822035/135963355-f2619e26-0054-4f8d-9814-d23238ae2632.JPG)

## Screenshots (LTR)

![ltr-1](https://user-images.githubusercontent.com/822035/135963383-55082932-9ba3-4c43-aeec-de5a71150be1.JPG)
![ltr-2](https://user-images.githubusercontent.com/822035/135963386-30cfd14c-e0bf-459e-b0a4-6aa01c82c346.JPG)

@u0pattern @SyafiqHadzir how does this look to you? Are there any other changes you would expect with this feature?