### PR TITLE
Fix a typo in the name of the GitHub username variable.

### DIFF
--- a/_includes/avatar.html
+++ b/_includes/avatar.html
@@ -1,6 +1,6 @@
 {% if site.dash.avatar_source == "github" and site.dash.github_username %}
 {% capture avatar_image %}
-    https://github.com/{{ site.github_username }}.png
+    https://github.com/{{ site.dash.github_username }}.png
 {% endcapture %}
 {% elsif site.dash.avatar_source == "local" and site.dash.avatar_path %}
 {% capture avatar_image %}


### PR DESCRIPTION
## Description

GitHub avatars were not shown correctly due to a typo in the username variable. This fixes it to use the correct variable.

## Addressed issues

N/A

## Screenshots

N/A