### PR TITLE
Fix linking to tags that contain a space in their name.

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -17,7 +17,7 @@ layout: default
             {% if site.plugins contains "jekyll/tagging" %}
             <div class="post-tags">
                 {% for tag in post.tags %}
-                <a class="tag" href="/tag/{{ tag }}/">{{ tag }}</a>
+                <a class="tag" href="{{ tag | tag_url }}">{{ tag }}</a>
                 {% endfor %}
             </div>
             {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,7 +9,7 @@ layout: default
   {% if site.plugins contains "jekyll/tagging" %}
   <div class="post-tags">
       {% for tag in page.tags %}
-      <a class="tag" href="/tag/{{ tag }}/">{{ tag }}</a>
+      <a class="tag" href="{{ tag | tag_url }}">{{ tag }}</a>
       {% endfor %}
   </div>
   {% endif %}

--- a/_layouts/tag_page.html
+++ b/_layouts/tag_page.html
@@ -17,7 +17,7 @@ layout: default
 
           <div class="post-tags">
               {% for tag in post.tags %}
-              <a class="tag" href="/tag/{{ tag }}/">{{ tag }}</a>
+              <a class="tag" href="{{ tag | tag_url }}">{{ tag }}</a>
               {% endfor %}
           </div>
           {% if site.dash.date_format %}


### PR DESCRIPTION
## Description

Jekyll allows you to specify tags as both a space-delimited string and an array of tags. If an array of tags is used then tags can contain spaces.

This pull request fixes jekyll-dash to correctly link to tag pages for tags which have a space in their name.

## Addressed issues

N/A

## Screenshots

N/A