### PR TITLE
Include CNAME file

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ If you are using a custom domain add in your main branch a file named CNAME with
 ```
 include: [CNAME]
 ```
+For more information about how to configure your CNAME file, read the [official documentation](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site).
 
 ## Additional Features
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ tag_permalink_style: pretty
 tag_page_layout: tag_page
 tag_page_dir: tag
 
+# for github pages custom domains:
+# include: [CNAME]
+
 dash:
   # the way how dates should be displayed
   date_format: "%b %-d, %Y"
@@ -114,6 +117,11 @@ Please keep in mind that Github Pages does only support [a limited list of Jekyl
 I have created [a guide on how to set this up here](https://bitbra.in/2021/10/03/host-your-own-blog-for-free-with-custom-domain.html).
 
 You are not required to do this, but keep in mind that some functionality might not be available when using the Jekyll generator on Github directly!
+
+If you are using a custom domain add in your main branch a file named CNAME with your domain there and uncomment this line in your config file:
+```
+include: [CNAME]
+```
 
 ## Additional Features
 


### PR DESCRIPTION
## Description

Following the tutorial to configure jekyll-dash in my github pages I had a problem envolving my custom domain.
After some hours debbuging I found the problem: When you configure a custom domain in GithubPages config, a file named "CNAME" will appear in your site branch, and inside this file wil have your domain name.
So when the Github pages action makes the push in gh-pages branch the CNAME file will be overwrited by request. And your configuration to use custom domains will be erased :(.
So I found a solution to this issue including this line in my config file:
```
include: [CNAME]
```
and adding CNAME file in my main branch. This includes CNAME in push request.
In this PR I just add this line commented in config example file and add some words in GithubPages topic. Fell free to make changes! 

## Addressed issues

- CNAME file overwrited by push request.
