### PR TITLE
Fix tags that contain a space

### DIFF
--- a/_layouts/tag_page.html
+++ b/_layouts/tag_page.html
@@ -4,7 +4,7 @@ layout: default
 {% unless site.dash.show_author == false %}
   {% include author.html %}
 {% endunless %}
-<h1 class="post-title">articles tagged with <a class="tag" href="/tag/{{ page.tag }}/">{{ page.tag }}</a></h1>
+<h1 class="post-title">articles tagged with <a class="tag" href="{{ page.tag | tag_url }}">{{ page.tag }}</a></h1>
   <div class="post-links">
   {% for post in site.posts %}
   {% for tag in post.tags %}


### PR DESCRIPTION
## Description

This pull request fixes `jekyll-dash` to correctly link to tag pages for tags which have a space in their name.

Similar issue existed in PR #81 .

## Addressed issues

N/A

## Screenshots

N/A
