### PR TITLE
Add post author after date if specified

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,12 @@ layout: default
       {% endfor %}
   </div>
   {% endif %}
-  <div class="post-date">Published on {{ page.date | date_to_string }}</div>
+  <div class="post-date">
+    Published on {{ page.date | date_to_string }}
+    {% if page.author != null %}
+    by {{ page.author }}
+    {% endif %}
+  </div>
   {% if page.description != null %}
   <noscript>
     <div class="post-description">{{ page.description }}</div>


### PR DESCRIPTION
## Description

A few of my posts were written in collaboration with others, and there was currently no place to put their name.
I added the option to show the author if the `author` field is specified on a post, alongside the date.

## Addressed issues

N/A

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/16872/182882094-c65530aa-95df-46a1-981d-1e527909dc12.png)

After:
![image](https://user-images.githubusercontent.com/16872/182882382-63dff997-b664-4112-aa48-2b0d062d9879.png)
