### PR TITLE
add font awesome free font to .fab class to allow non-brands icons in socials links section.

### DIFF
--- a/_sass/fa/brands.scss
+++ b/_sass/fa/brands.scss
@@ -18,5 +18,5 @@
 }
 
 .fab {
-  font-family: 'Font Awesome 5 Brands';
+  font-family: 'Font Awesome 5 Brands', 'Font Awesome 5 Free';
 }


### PR DESCRIPTION
## Description
Currently only the font awesome brands icons work when configuring the socials section in the _config.yml. This will make it possible to also use the standard font awesome icons.

The Font Awesome 5 Free font is already imported in https://github.com/bitbrain/jekyll-dash/blob/main/_sass/dash.scss. Also it is being used for the Tags icon.
 
## Addressed issues

## Screenshots
![image](https://user-images.githubusercontent.com/4581237/212294401-a289366b-11b0-40c2-a3f2-872033f676af.png)
