### PR TITLE
Add support for rel attribute in social media links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,9 +4,9 @@
     <span class="social_links">
         {% for link in site.dash.social_links %}
         {% if link.fa == true %}
-        <a class="color-{{ link.color }}-hover" href="{{ link.url }}"><i class="fa fa-{{ link.icon }}"></i></a>
+        <a class="color-{{ link.color }}-hover" href="{{ link.url }}"{% if link.rel %} rel="{{ link.rel }}"{% endif %}><i class="fa fa-{{ link.icon }}"></i></a>
         {% else %}
-        <a class="color-{{ link.color }}-hover" href="{{ link.url }}"><i class="fab fa-{{ link.icon }}"></i></a>
+        <a class="color-{{ link.color }}-hover" href="{{ link.url }}"{% if link.rel %} rel="{{ link.rel }}"{% endif %}><i class="fab fa-{{ link.icon }}"></i></a>
         {% endif %}
         {% endfor %}
     </span>


### PR DESCRIPTION
## Description
Add support for `rel` attribute in social media links in the header.
Particularly `rel="me"` is of interest when verifying links in for instance a Mastodon profile.

## Addressed issues

- Adds the possibility to add `rel="me"` (or possibly other values) to your social media links in the header

## Screenshots

No visual change, but allows services that validate that a link to your jekyll-dash based blog in your profile is actually yours.

Config can look something like this:

```
  social_links:
    - url: https://mastodon.social/@myuser
      icon: mastodon
      color: purple
      rel: me
```